### PR TITLE
Support UTF-8 in value obfuscator

### DIFF
--- a/logging/ValueObfuscator.go
+++ b/logging/ValueObfuscator.go
@@ -2,6 +2,7 @@ package logging
 
 import (
 	"bytes"
+	"unicode/utf8"
 )
 
 type valueObfuscator struct {
@@ -30,7 +31,7 @@ func valueObfuscatorWithKeepingEndCount(count int) valueObfuscator {
 }
 
 func (vo valueObfuscator) obfuscateValue(value string) (string, error) {
-	valueLength := len(value)
+	valueLength := utf8.RuneCountInString(value)
 
 	if valueLength == 0 {
 		return value, nil
@@ -42,13 +43,18 @@ func (vo valueObfuscator) obfuscateValue(value string) (string, error) {
 		return value, nil
 	}
 
-	chars := []rune(value)
-
-	for i := vo.keepStartCount; i < valueLength - vo.keepEndCount; i++ {
-		chars[i] = vo.maskCharacter
+	var chars bytes.Buffer
+	i := 0
+	for _, r := range value {
+		if i < vo.keepStartCount || i >= valueLength-vo.keepEndCount {
+			chars.WriteRune(r)
+		} else {
+			chars.WriteRune(vo.maskCharacter)
+		}
+		i++
 	}
 
-	return string(chars), nil
+	return chars.String(), nil
 }
 
 func (vo valueObfuscator) repeatMask(count int) string {

--- a/logging/ValueObfuscator_test.go
+++ b/logging/ValueObfuscator_test.go
@@ -1,0 +1,24 @@
+package logging
+
+import "testing"
+
+func TestObfuscateUnicodeValue(t *testing.T) {
+	value := "Hello, 世界"
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("TestObfuscateUnicodeValue : panic on obfuscate value '%v': %v", value, r)
+		}
+	}()
+
+	vo := valueObfuscatorWithAll()
+	actual, err := vo.obfuscateValue(value)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "*********"
+	if actual != expected {
+		t.Fatalf("TestObfuscateUnicodeValue : expected '%s' got '%s'", expected, actual)
+	}
+}


### PR DESCRIPTION
These changes fix `index out of range` in `connect-sdk-go/logging/ValueObfuscator.go:48` in case of value contains UTF-8 runes